### PR TITLE
Fix the behaviour when no columns are available for value comparison.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ check: ## Runs checks using ruff, black, mypy and pytest
 
 .PHONY: test
 test: ## Runs tests
-	-pytest --doctest-glob="README.md" -v
+	-pytest --doctest-glob="README.md" -s

--- a/README.md
+++ b/README.md
@@ -643,10 +643,10 @@ End of Report
 - [x] Fix report output when tables are exactly equal.
 - [x] Github actions for testing
 - [x] Github actions for linting
-- [ ] Add message when there are no columns left to be compared.
-- [ ] Add message when df's are exactly equal. 
-- [ ] Add test case with exactly equal dfs.
-- [ ] Add test case with no columns being compared. Make sure an error is raised when the value_summary and value_sample methods are called.
+- [x] Add message when there are no columns left to be compared.
+- [x] Add message when df's are exactly equal. 
+- [x] Add test case with exactly equal dfs.
+- [x] Add test case with no columns being compared. Make sure an error is raised when the value_summary and value_sample methods are called.
 - [] Test for large amounts of data
 - [] Benchmark for different sizes of data.
 - [] Investigate use for very large datasets 50GB-100GB. Can this be done using LazyFrames only?

--- a/README.md
+++ b/README.md
@@ -643,6 +643,10 @@ End of Report
 - [x] Fix report output when tables are exactly equal.
 - [x] Github actions for testing
 - [x] Github actions for linting
+- [ ] Add message when there are no columns left to be compared.
+- [ ] Add message when df's are exactly equal. 
+- [ ] Add test case with exactly equal dfs.
+- [ ] Add test case with no columns being compared. Make sure an error is raised when the value_summary and value_sample methods are called.
 - [] Test for large amounts of data
 - [] Benchmark for different sizes of data.
 - [] Investigate use for very large datasets 50GB-100GB. Can this be done using LazyFrames only?

--- a/pl_compare/compare.py
+++ b/pl_compare/compare.py
@@ -696,7 +696,7 @@ class compare:
         return len(get_columns_to_compare(self._comparison_metadata)) > 0
         
 
-    def report(self, print: Union[Callable[[str], None], None] = print) -> Union[FuncAppend, None]:
+    def report(self, print: Union[Callable[[str], None], None] = None) -> Union[FuncAppend, None]:
         """
         Generate a report of the comparison results.
 

--- a/pl_compare/compare.py
+++ b/pl_compare/compare.py
@@ -712,7 +712,7 @@ class compare:
         combined.append(80 * "-")
         if self.is_equal():
             combined.append("Tables are exactly equal.")
-            combined.append(f"\nSUMMARY:\n{self.summary()}")
+            combined.append(f"\nSUMMARY:\n{self.summary().filter(pl.col('Count')!=0)}")
             return combined
         if not self.is_schemas_equal():
             combined.append(

--- a/pl_compare/compare.py
+++ b/pl_compare/compare.py
@@ -726,12 +726,14 @@ class compare:
         else:
             combined.append("No Row differences found (when joining by the supplied join_columns).")
         combined.append(80 * "-")
-        if not self.is_values_equal() and self._value_comparison_columns_exist():
+        if not self._value_comparison_columns_exist():
+            combined.append("No columns to compare.")
+        elif self.is_values_equal():
+            combined.append("No Column Value differences found.")
+        elif not self.is_values_equal() :
             combined.append(
                 f"\nVALUE DIFFERENCES:\n{self.values_summary()}\n{self.values_sample()}"
             )
-        else:
-            combined.append("No Column Value differences found.")
         combined.append(80 * "-")
         combined.append("End of Report")
         combined.append(80 * "-")

--- a/pl_compare/tests/test_compare.py
+++ b/pl_compare/tests/test_compare.py
@@ -33,6 +33,18 @@ def test_expected_values_returned_for_bools_for_equal_dfs_none_id_columns(base_d
     assert compare_result.is_rows_equal() is True
     assert compare_result.is_values_equal() is True
     assert compare_result.is_equal() is True
+    assert """┌─────────────────────────────┬───────┐
+│ Statistic                   ┆ Count │
+│ ---                         ┆ ---   │
+│ str                         ┆ i64   │
+╞═════════════════════════════╪═══════╡
+│ Columns in base             ┆ 4     │
+│ Columns in compare          ┆ 4     │
+│ Columns in base and compare ┆ 4     │
+│ Rows in base                ┆ 3     │
+│ Rows in compare             ┆ 3     │
+│ Rows in base and compare    ┆ 3     │
+└─────────────────────────────┴───────┘""" in str(compare_result.report())
 
 
 def test_expected_values_returned_for_bools_for_unequal_dfs(base_df, compare_df):
@@ -348,3 +360,32 @@ def test_error_raised_when_dupes_supplied_for_1_1_validation():
     compare(["ID", "ID2"], base_df, compare_df, "m:1").rows_summary()
     compare(["ID", "ID2"], compare_df, base_df, "1:m").values_summary()
     compare(["ID", "ID2"], compare_df, base_df, "1:m").rows_summary()
+
+
+
+def test_error_raised_when_no_columns_to_compare_exist():
+    base_df = pl.DataFrame(
+        {
+            "ID": ["123456", "123456", "1234567", "12345678"],
+            "ID2": ["123456", "123457", "1234567", "12345678"],
+            "ID3": ["123456", "123457", "1234567", "12345678"],
+            "ID4": ["123456", "123457", "1234567", "12345678"],
+        }
+    )
+    compare_df = pl.DataFrame(
+        {
+            "ID": ["123456", "1234567", "1234567810"],
+            "ID2": ["123456", "1234567", "1234567810"],
+            "ID3": ["123456", "1234567", "1234567810"],
+            "ID4": ["123456", "1234567", "1234567810"],
+        },
+    )
+
+    with pytest.raises(Exception) as exc_info:
+        compare(["ID", "ID2", "ID3", "ID4"], base_df, compare_df, validate="1:1").values_summary()
+    assert exc_info.value.args[0] == 'There are no columns to compare the value of. Please check the columns in the base and compare datasets as well as the join columns that have been supplied.'
+
+    with pytest.raises(Exception) as exc_info:
+        compare(["ID", "ID2", "ID3", "ID4"], base_df, compare_df, validate="1:1").values_sample()
+    assert exc_info.value.args[0] == 'There are no columns to compare the value of. Please check the columns in the base and compare datasets as well as the join columns that have been supplied.'
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pl_compare"
-version = "0.5.0"
+version = "0.5.1"
 description = "A tool to find the differences between two tables."
 authors = ["Your Name <you@example.com>"]
 readme = "README.md"


### PR DESCRIPTION
- Fix the behaviour when no columns are available for value comparison. With tests.
- Add a statistics summary to be printed when tables are exactly equal. With tests.