### PR TITLE
Allow join_column to be named `status`

### DIFF
--- a/pl_compare/compare.py
+++ b/pl_compare/compare.py
@@ -105,8 +105,9 @@ def get_base_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
         how="anti",
     )
     return combined_table.select(
-        meta.join_columns + [pl.lit(f"in {meta.base_alias} only").alias("status")]
-    ).unpivot(index=meta.join_columns, on=["status"])
+        meta.join_columns
+        + [pl.lit("status").alias("variable"), pl.lit(f"in {meta.base_alias} only").alias("value")]
+    )
 
 
 def get_compare_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
@@ -114,8 +115,12 @@ def get_compare_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
         meta.base_df.select(meta.join_columns), on=meta.join_columns, how="anti"
     )
     return combined_table.select(
-        meta.join_columns + [pl.lit(f"in {meta.compare_alias} only").alias("status")]
-    ).unpivot(index=meta.join_columns, on=["status"])
+        meta.join_columns
+        + [
+            pl.lit("status").alias("variable"),
+            pl.lit(f"in {meta.compare_alias} only").alias("value"),
+        ]
+    )
 
 
 def get_row_differences(meta: ComparisonMetadata) -> pl.LazyFrame:


### PR DESCRIPTION
Previously, the following failed because pl_compare internally used a temporary column called "status" that conflicts with a potentially existing column in `meta.join_columns` of the same name:

```
import polars as pl
from pl_compare import compare

base_df = pl.DataFrame(
  {
    "status": ["123456", "1234567", "12345678"],
    "Example1": [1, 6, 3],
  }
)
compare_df = pl.DataFrame(
  {
    "status": ["123456", "1234567", "1234567810"],
    "Example1": [1, 2, 3],
  }
)

compare_result = compare(["status"], base_df, compare_df)
print(compare_result.rows_sample())
```

The new code does not use a temporary column, which fixes the above example.