### PR TITLE
allow join_column to be named `value` or `variable`

### DIFF
--- a/pl_compare/compare.py
+++ b/pl_compare/compare.py
@@ -18,6 +18,8 @@ class ComparisonMetadata:
     sample_limit: Optional[int]
     base_alias: str
     compare_alias: str
+    value_alias: str
+    variable_alias: str
     schema_comparison: bool
     hide_empty_stats: bool
     validate: Literal["m:m", "m:1", "1:m", "1:1"]
@@ -106,7 +108,10 @@ def get_base_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
     )
     return combined_table.select(
         meta.join_columns
-        + [pl.lit("status").alias("variable"), pl.lit(f"in {meta.base_alias} only").alias("value")]
+        + [
+            pl.lit("status").alias(meta.variable_alias),
+            pl.lit(f"in {meta.base_alias} only").alias(meta.value_alias),
+        ]
     )
 
 
@@ -117,8 +122,8 @@ def get_compare_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
     return combined_table.select(
         meta.join_columns
         + [
-            pl.lit("status").alias("variable"),
-            pl.lit(f"in {meta.compare_alias} only").alias("value"),
+            pl.lit("status").alias(meta.variable_alias),
+            pl.lit(f"in {meta.compare_alias} only").alias(meta.value_alias),
         ]
     )
 
@@ -216,10 +221,10 @@ def get_combined_tables(
 def summarise_value_difference(meta: ComparisonMetadata) -> pl.DataFrame:
     value_differences = get_column_value_differences(meta)
     final_df = (
-        value_differences.group_by(["variable"])
+        value_differences.group_by([meta.variable_alias])
         .agg(pl.sum("has_diff"))
-        .sort("variable", descending=False)
-        .rename({"variable": "Value Differences", "has_diff": "Count"})
+        .sort(meta.variable_alias, descending=False)
+        .rename({meta.variable_alias: "Value Differences", "has_diff": "Count"})
     )
     total_value_comparisons = value_differences.select(
         pl.lit("Total Value Comparisons").alias("Value Differences"),
@@ -321,19 +326,22 @@ def get_column_value_differences(meta: ComparisonMetadata) -> pl.DataFrame:
     melted_df = temp.unpivot(
         index=meta.join_columns,
         on=[col for col, format in compare_columns.items()],
+        variable_name=meta.variable_alias,
+        value_name=meta.value_alias,
     )
-    # melted_df = melted_df.with_columns(pl.col("value").str.json_decode(dtype).alias("value"))
 
     if convert_to_dataframe(melted_df).height > 0 and len(compare_columns) > 0:
         melted_df = (
             melted_df.with_columns(
-                pl.col("value").str.json_path_match(f"$.{meta.base_alias}").alias(meta.base_alias),
-                pl.col("value")
+                pl.col(meta.value_alias)
+                .str.json_path_match(f"$.{meta.base_alias}")
+                .alias(meta.base_alias),
+                pl.col(meta.value_alias)
                 .str.json_path_match(f"$.{meta.compare_alias}")
                 .alias(meta.compare_alias),
-                pl.col("value").str.json_path_match("$.has_diff").alias("has_diff"),
+                pl.col(meta.value_alias).str.json_path_match("$.has_diff").alias("has_diff"),
             )
-            .drop(["value"])
+            .drop([meta.value_alias])
             .with_columns(pl.col("has_diff").replace_strict({"false": False, "true": True}))
         )
     else:
@@ -348,7 +356,9 @@ def get_column_value_differences_filtered(meta: ComparisonMetadata) -> pl.DataFr
     if meta.sample_limit is not None:
         filtered_df = (
             filtered_df.with_columns(pl.lit(1).alias("ones"))
-            .with_columns(pl.col("ones").cum_sum().over("variable").alias("rows_sample_number"))
+            .with_columns(
+                pl.col("ones").cum_sum().over(meta.variable_alias).alias("rows_sample_number")
+            )
             .filter(pl.col("rows_sample_number") <= pl.lit(meta.sample_limit))
             .drop("ones", "rows_sample_number")
         )
@@ -379,11 +389,13 @@ def get_schema_comparison(meta: ComparisonMetadata) -> pl.DataFrame:
             sample_limit=None,
             base_alias=f"{meta.base_alias}_format",
             compare_alias=f"{meta.compare_alias}_format",
+            value_alias=meta.value_alias,
+            variable_alias=meta.variable_alias,
             schema_comparison=True,
             hide_empty_stats=False,
             validate="1:1",
         )
-    ).drop("variable")
+    ).drop(meta.variable_alias)
 
 
 def summarise_column_differences(meta: ComparisonMetadata) -> pl.LazyFrame:
@@ -472,6 +484,8 @@ class compare:
         sample_limit: Optional[int] = 5,
         base_alias: str = "base",
         compare_alias: str = "compare",
+        value_alias: str = "value",
+        variable_alias: str = "variable",
         hide_empty_stats: bool = False,
         validate: Literal["m:m", "m:1", "1:m", "1:1"] = "m:m",
     ):
@@ -488,6 +502,8 @@ class compare:
             sample_limit (Optional[int]): The number of rows to sample from the comparison. This only applies to methods that return a sample.
             base_alias (str): The alias for the base dataframe. This will be displayed in the final result.
             compare_alias (str): The alias for the dataframe to be compared. This will be displayed in the final result.
+            value_alias (str): The alias for "value" column. This will be displayed in the final result.
+            variable_alias (str): The alias for the "variable" column. This will be displayed in the final result.
             hide_empty_stats (bool): Whether to hide empty statistics. Comparison statistics where there are zero differences will be excluded from the result.
             validate (str): Checks if join is of specified type {‘m:m’, ‘m:1’, ‘1:m’, ‘1:1’ }.
         """
@@ -510,6 +526,8 @@ class compare:
             sample_limit,
             base_alias,
             compare_alias,
+            value_alias,
+            variable_alias,
             False,
             hide_empty_stats,
             validate,

--- a/pl_compare/tests/test_compare.py
+++ b/pl_compare/tests/test_compare.py
@@ -105,6 +105,37 @@ shape: (1, 4)
     )
 
 
+@pytest.mark.parametrize("column_name", ["value", "variable"])
+def test_special_column_names(column_name):
+    base_df = pl.DataFrame({column_name: ["123", "456", "888"], "x": [1, 2, 3]})
+    compare_df = pl.DataFrame({column_name: ["123", "456", "789"], "x": [1, 22, 3]})
+    expected_rows = pl.DataFrame(
+        {
+            column_name: ["888", "789"],
+            "-variable": ["status", "status"],
+            "-value": ["in base only", "in compare only"],
+        }
+    )
+    expected_values = pl.DataFrame(
+        {
+            column_name: ["456"],
+            "-variable": ["x"],
+            "base": ["2"],
+            "compare": ["22"],
+        }
+    )
+
+    # Without value_alias and variable_alias, the special column names would produce
+    #    polars.exceptions.DuplicateError: projections contained duplicate output name 'variable'
+    # because the same column names are used internally.
+    compare_result = compare(
+        [column_name], base_df, compare_df, value_alias="-value", variable_alias="-variable"
+    )
+
+    pl.testing.assert_frame_equal(compare_result.rows_sample(), expected_rows)
+    pl.testing.assert_frame_equal(compare_result.values_sample(), expected_values)
+
+
 def test_expected_values_returned_for_bools_for_equal_dfs_none_id_columns(base_df):
     compare_result = compare(None, base_df, base_df)
     assert compare_result.is_schemas_equal() is True


### PR DESCRIPTION
Previously this failed because pl_compare wanted to insert columns of the same name into the final result. This is a follow-up to https://github.com/concur1/pl_compare/pull/21.

Technically speaking, inserting the new arguments for `compare()` somewhere in the middle is a breaking change: If someone actually passes all these arguments by position (not by keyword), things would break. But it really makes sense to have all aliases grouped together. That said, how about turning all the optional arguments into [keyword-only parameters](https://peps.python.org/pep-3102/)? Defining it like
```
def __init__(
        self,
        join_columns: Union[List[str], None],
        base_df: Union[pl.LazyFrame, pl.DataFrame],
        compare_df: Union[pl.LazyFrame, pl.DataFrame],
        *,  # everything from here on is keyword-only
        streaming: bool = False,
        [...]
```
would allow passing the first three arguments to be passed by position. Only the optional parameters would have to be passed by keyword, thus enforcing clarity when many parameters are passed. It would also allow more flexibility when adding new parameters.