### PR TITLE
fix `make format` for ruff 0.5 or higher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ help: ## Print help for make commands
 
 .PHONY: format
 format: ## Formats the files with ruff and black
-	-ruff --fix $(SRCPATH)
+	-ruff check --fix $(SRCPATH)
 	-black $(SRCPATH)
-	-ruff $(SRCPATH)
+	-ruff check $(SRCPATH)
 	-black --check $(SRCPATH)
 
 .PHONY: check

--- a/pl_compare/tests/test_compare.py
+++ b/pl_compare/tests/test_compare.py
@@ -594,4 +594,4 @@ def test_usage_of_status_column():
     )
 
     # This should not cause an error
-    compare_result = compare(["status"], base_df, compare_df)
+    compare(["status"], base_df, compare_df)


### PR DESCRIPTION
Since ruff 0.5 it is mandatory to pass the `check` parameter. The additionaly parameter also works for ruff version 0.3.0.

Also fix the only thing that ruff was complaining about: An unused variable in one of the tests.