### PR TITLE
Fix column conflicts

### DIFF
--- a/pl_compare/compare.py
+++ b/pl_compare/compare.py
@@ -1,8 +1,112 @@
 from dataclasses import dataclass
 from typing import Literal, Callable, List, Union, Dict, Optional
+from functools import wraps
 
 import polars as pl
 from polars.datatypes.classes import DataTypeClass
+
+
+def apply_column_renames(func: Callable):
+    """
+    Decorator to apply column renames from column mapping to the result DataFrame/LazyFrame.
+    This decorator automatically renames internal column names to their final output names
+    based on the column mapping in the ComparisonMetadata.
+
+    Args:
+        func: The function that returns a DataFrame or LazyFrame to be renamed
+
+    Returns:
+        A wrapped function that applies column renames to the result
+    """
+
+    @wraps(func)
+    def wrapper(meta: ComparisonMetadata, *args, **kwargs):
+        result = func(meta, *args, **kwargs)
+        if not isinstance(result, pl.LazyFrame) and not isinstance(result, pl.DataFrame):
+            raise TypeError(
+                f"Expected result to be a polars DataFrame or LazyFrame, "
+                f"but got {type(result).__name__}. "
+                f"The @apply_column_renames decorator can only be applied to functions "
+                f"that return polars DataFrames or LazyFrames."
+            )
+
+        if isinstance(result, pl.LazyFrame):
+            result_columns = result.collect_schema().names()
+            rename_mapping = {}
+            
+               
+        if isinstance(result, pl.DataFrame):
+            result_columns = result.columns
+            rename_mapping = {}
+            
+        for internal_col, output_col in meta.column_mapping.mapping.items():
+            if internal_col in result_columns and internal_col != output_col:
+                rename_mapping[internal_col] = output_col
+        
+        if rename_mapping:
+            result = result.rename(rename_mapping)
+
+                
+        return result
+
+    return wrapper
+
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ColumnMapping:
+    """Class for holding internal column names and their mappings to output names."""
+
+    mapping: Dict[str, str]
+    in_base: str = "__pl_compare_in_base"
+    in_compare: str = "__pl_compare_in_compare"
+    value: str = "__pl_compare_value"
+    variable: str = "__pl_compare_variable"
+    base: str = "__pl_compare_base"
+    compare: str = "__pl_compare_compare"
+    status: str = "__pl_compare_status"
+
+
+def _generate_column_mapping(
+    user_columns: List[str],
+    value_alias: str = "value",
+    variable_alias: str = "variable",
+    base_alias: str = "base",
+    compare_alias: str = "compare",
+) -> ColumnMapping:
+    """
+    Generate a mapping of internal column names to output column names.
+
+    This function creates a ColumnMapping object that contains both the internal column names
+    and the mapping from internal names to output names.
+
+    Args:
+        user_columns: List of column names from user dataframes
+        value_alias: Desired output name for value column
+        variable_alias: Desired output name for variable column
+        base_alias: Desired output name for base column
+        compare_alias: Desired output name for compare column
+
+    Returns:
+        ColumnMapping object containing internal names and their mappings to output names
+    """
+    # Simple mapping: all internal columns use __pl_compare_ prefix
+    # This ensures no conflicts with user columns since internal names are unique
+    return ColumnMapping(
+        mapping={
+            # Critical internal columns used in join operations
+            "__pl_compare_in_base": "in_base",
+            "__pl_compare_in_compare": "in_compare",
+            # Output columns that appear in final results
+            "__pl_compare_value": value_alias,
+            "__pl_compare_variable": variable_alias,
+            "__pl_compare_base": base_alias,
+            "__pl_compare_compare": compare_alias,
+            "__pl_compare_status": variable_alias,  # status is used internally but appears as variable in output
+        }
+    )
 
 
 @dataclass
@@ -23,6 +127,7 @@ class ComparisonMetadata:
     schema_comparison: bool
     hide_empty_stats: bool
     validate: Literal["m:m", "m:1", "1:m", "1:1"]
+    column_mapping: ColumnMapping
 
 
 def convert_to_dataframe(df: Union[pl.LazyFrame, pl.DataFrame]) -> pl.DataFrame:
@@ -56,30 +161,36 @@ def get_uncertain_row_count(df: pl.LazyFrame) -> int:
 
 
 def get_row_comparison_summary(meta: ComparisonMetadata) -> pl.DataFrame:
-    combined_table = meta.base_df.select(meta.join_columns + [pl.lit(True).alias("in_base")]).join(
-        meta.compare_df.select(meta.join_columns + [pl.lit(True).alias("in_compare")]),
+    in_base_col = meta.column_mapping.in_base
+    in_compare_col = meta.column_mapping.in_compare
+
+    combined_table = meta.base_df.select(
+        meta.join_columns + [pl.lit(True).alias(in_base_col)]
+    ).join(
+        meta.compare_df.select(meta.join_columns + [pl.lit(True).alias(in_compare_col)]),
         on=meta.join_columns,
         how="full",
         coalesce=True,
         validate=meta.validate,
     )
     grouped_rows = (
-        combined_table.select(meta.join_columns + ["in_base", "in_compare"])
-        .group_by(["in_base", "in_compare"])
+        combined_table.select(meta.join_columns + [in_base_col, in_compare_col])
+        .group_by([in_base_col, in_compare_col])
         .agg(pl.len().alias("Count"))
     )
+
     base_only_rows = get_uncertain_row_count(
-        grouped_rows.filter(pl.col("in_base") & pl.col("in_compare").is_null())
+        grouped_rows.filter(pl.col(in_base_col) & pl.col(in_compare_col).is_null())
     )
     compare_only_rows = get_uncertain_row_count(
-        grouped_rows.filter(pl.col("in_base").is_null() & pl.col("in_compare"))
+        grouped_rows.filter(pl.col(in_base_col).is_null() & pl.col(in_compare_col))
     )
     shared_rows = get_uncertain_row_count(
         grouped_rows.filter(
-            pl.col("in_base")
-            & pl.col("in_base").is_not_null()
-            & pl.col("in_compare")
-            & pl.col("in_compare").is_not_null()
+            pl.col(in_base_col)
+            & pl.col(in_base_col).is_not_null()
+            & pl.col(in_compare_col)
+            & pl.col(in_compare_col).is_not_null()
         )
     )
     final_df = (
@@ -109,8 +220,8 @@ def get_base_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
     return combined_table.select(
         meta.join_columns
         + [
-            pl.lit("status").alias(meta.variable_alias),
-            pl.lit(f"in {meta.base_alias} only").alias(meta.value_alias),
+            pl.lit("status").alias(meta.column_mapping.status),
+            pl.lit(f"in {meta.base_alias} only").alias(meta.column_mapping.value),
         ]
     )
 
@@ -122,18 +233,20 @@ def get_compare_only_rows(meta: ComparisonMetadata) -> pl.LazyFrame:
     return combined_table.select(
         meta.join_columns
         + [
-            pl.lit("status").alias(meta.variable_alias),
-            pl.lit(f"in {meta.compare_alias} only").alias(meta.value_alias),
+            pl.lit("status").alias(meta.column_mapping.status),
+            pl.lit(f"in {meta.compare_alias} only").alias(meta.column_mapping.value),
         ]
     )
 
 
+@apply_column_renames
 def get_row_differences(meta: ComparisonMetadata) -> pl.LazyFrame:
     base_only_rows = get_base_only_rows(meta).with_row_index()
     compare_only_rows = get_compare_only_rows(meta).with_row_index()
     if meta.sample_limit is not None:
         base_only_rows = base_only_rows.limit(meta.sample_limit)
         compare_only_rows = compare_only_rows.limit(meta.sample_limit)
+
     return (
         pl.concat(
             [
@@ -193,26 +306,31 @@ def get_combined_tables(
     base_df: pl.LazyFrame,
     compare_df: pl.LazyFrame,
     compare_columns: Dict[str, Union[DataTypeClass, pl.DataType]],
-    equality_check: Union[Callable[[str, Union[pl.DataType, DataTypeClass]], pl.Expr], None],
-    coalesce: bool,
+    meta: ComparisonMetadata,
     how_join: Literal["inner", "full"] = "inner",
-    resolution: Union[float, None] = None,
-    validate: Literal["m:m", "m:1", "1:m", "1:1"] = "1:1",
+    coalesce: bool = False,
 ) -> pl.LazyFrame:
     base_df = base_df.rename({col: f"{col}_base" for col, format in compare_columns.items()})
     compare_df = compare_df.rename(
         {col: f"{col}_compare" for col, format in compare_columns.items()}
     )
-    compare_df = base_df.with_columns([pl.lit(True).alias("in_base")]).join(
-        compare_df.with_columns([pl.lit(True).alias("in_compare")]),
+
+    # Get column names directly from meta's column mapping
+    in_base_col = meta.column_mapping.in_base
+    in_compare_col = meta.column_mapping.in_compare
+
+    compare_df = base_df.with_columns([pl.lit(True).alias(in_base_col)]).join(
+        compare_df.with_columns([pl.lit(True).alias(in_compare_col)]),
         on=join_columns,
         how=how_join,
         coalesce=coalesce,
-        validate=validate,
+        validate="1:1",
     )
     return compare_df.with_columns(
         [
-            get_equality_check(equality_check, resolution, col, format).alias(f"{col}_has_diff")
+            get_equality_check(meta.equality_check, meta.resolution, col, format).alias(
+                f"{col}_has_diff"
+            )
             for col, format in compare_columns.items()
         ]
     )
@@ -220,11 +338,12 @@ def get_combined_tables(
 
 def summarise_value_difference(meta: ComparisonMetadata) -> pl.DataFrame:
     value_differences = get_column_value_differences(meta)
+    variable_alias = meta.column_mapping.mapping[meta.column_mapping.variable]
     final_df = (
-        value_differences.group_by([meta.variable_alias])
+        value_differences.group_by([variable_alias])
         .agg(pl.sum("has_diff"))
-        .sort(meta.variable_alias, descending=False)
-        .rename({meta.variable_alias: "Value Differences", "has_diff": "Count"})
+        .sort(variable_alias, descending=False)
+        .rename({variable_alias: "Value Differences", "has_diff": "Count"})
     )
     total_value_comparisons = value_differences.select(
         pl.lit("Total Value Comparisons").alias("Value Differences"),
@@ -291,6 +410,7 @@ def get_columns_to_compare(
     }
 
 
+@apply_column_renames
 def get_column_value_differences(meta: ComparisonMetadata) -> pl.DataFrame:
     how_join: Literal["inner", "full"] = "inner"
     coalesce: bool = False
@@ -303,11 +423,9 @@ def get_column_value_differences(meta: ComparisonMetadata) -> pl.DataFrame:
         meta.base_df,
         meta.compare_df,
         compare_columns,
-        meta.equality_check,
-        resolution=meta.resolution,
-        coalesce=coalesce,
+        meta,
         how_join=how_join,
-        validate=meta.validate,
+        coalesce=coalesce,
     )
     temp = combined_tables.with_columns(
         [
@@ -323,42 +441,49 @@ def get_column_value_differences(meta: ComparisonMetadata) -> pl.DataFrame:
         ]
     )
 
+    # Use internal column names from column mapping for unpivot to avoid conflicts
+    internal_variable_col = meta.column_mapping.variable
+    internal_value_col = meta.column_mapping.value
+
     melted_df = temp.unpivot(
         index=meta.join_columns,
         on=[col for col, format in compare_columns.items()],
-        variable_name=meta.variable_alias,
-        value_name=meta.value_alias,
+        variable_name=internal_variable_col,
+        value_name=internal_value_col,
     )
 
     if convert_to_dataframe(melted_df).height > 0 and len(compare_columns) > 0:
+        # Use internal column names for processing
         melted_df = (
             melted_df.with_columns(
-                pl.col(meta.value_alias)
+                pl.col(internal_value_col)
                 .str.json_path_match(f"$.{meta.base_alias}")
-                .alias(meta.base_alias),
-                pl.col(meta.value_alias)
+                .alias(meta.column_mapping.base),
+                pl.col(internal_value_col)
                 .str.json_path_match(f"$.{meta.compare_alias}")
-                .alias(meta.compare_alias),
-                pl.col(meta.value_alias).str.json_path_match("$.has_diff").alias("has_diff"),
+                .alias(meta.column_mapping.compare),
+                pl.col(internal_value_col).str.json_path_match("$.has_diff").alias("has_diff"),
             )
-            .drop([meta.value_alias])
+            .drop([internal_value_col])
             .with_columns(pl.col("has_diff").replace_strict({"false": False, "true": True}))
         )
     else:
         melted_df = melted_df.with_columns(pl.lit(False).alias("has_diff"))
 
-    return melted_df.collect()
+    result = melted_df.collect()
+
+    return result
 
 
 def get_column_value_differences_filtered(meta: ComparisonMetadata) -> pl.DataFrame:
     df = get_column_value_differences(meta)
     filtered_df = df.filter(pl.col("has_diff")).drop("has_diff")
     if meta.sample_limit is not None:
+        # Use the final variable alias for grouping
+        variable_col = meta.column_mapping.mapping[meta.column_mapping.variable]
         filtered_df = (
             filtered_df.with_columns(pl.lit(1).alias("ones"))
-            .with_columns(
-                pl.col("ones").cum_sum().over(meta.variable_alias).alias("rows_sample_number")
-            )
+            .with_columns(pl.col("ones").cum_sum().over(variable_col).alias("rows_sample_number"))
             .filter(pl.col("rows_sample_number") <= pl.lit(meta.sample_limit))
             .drop("ones", "rows_sample_number")
         )
@@ -378,6 +503,12 @@ def get_schema_comparison(meta: ComparisonMetadata) -> pl.DataFrame:
             "format": [str(val) for val in meta.compare_df.collect().schema.values()],
         }
     )
+    # For schema comparison, we need to create a new column mapping with format-specific aliases
+    format_column_mapping = _generate_column_mapping(
+        ["column"],  # Only the column join column
+        base_alias=f"{meta.base_alias}_format",
+        compare_alias=f"{meta.compare_alias}_format",
+    )
     return get_column_value_differences_filtered(
         ComparisonMetadata(
             join_columns=["column"],
@@ -394,17 +525,24 @@ def get_schema_comparison(meta: ComparisonMetadata) -> pl.DataFrame:
             schema_comparison=True,
             hide_empty_stats=False,
             validate="1:1",
+            column_mapping=format_column_mapping,
         )
-    ).drop(meta.variable_alias)
+    ).drop(
+        "variable"
+    )  # Drop the variable column to match expected schema comparison format
 
 
 def summarise_column_differences(meta: ComparisonMetadata) -> pl.LazyFrame:
     schema_comparison = get_schema_comparison(meta)
+    # Schema comparison returns columns with _format suffix
+    base_format_col = f"{meta.base_alias}_format"
+    compare_format_col = f"{meta.compare_alias}_format"
+
     schema_differences = (
         schema_comparison.filter(
-            pl.col(f"{meta.base_alias}_format").is_not_null()
-            & pl.col(f"{meta.compare_alias}_format").is_not_null()
-            & (pl.col(f"{meta.base_alias}_format") != pl.col(f"{meta.compare_alias}_format"))
+            pl.col(base_format_col).is_not_null()
+            & pl.col(compare_format_col).is_not_null()
+            & (pl.col(base_format_col) != pl.col(compare_format_col))
         )
         .select(pl.len().alias("Count"))
         .item()
@@ -476,6 +614,7 @@ class compare:
         join_columns: Union[List[str], None],
         base_df: Union[pl.LazyFrame, pl.DataFrame],
         compare_df: Union[pl.LazyFrame, pl.DataFrame],
+        *,  # Everything from here is keyword-only
         streaming: bool = False,
         resolution: Union[float, None] = None,
         equality_check: Union[
@@ -516,6 +655,35 @@ class compare:
             )
             join_columns = ["row_number"]
 
+        # Always prefix ALL join columns to avoid conflicts with our output columns
+        join_column_renames = {col: f"join_columns.{col}" for col in join_columns}
+        base_lazy_df = base_lazy_df.rename(join_column_renames)
+        compare_lazy_df = compare_lazy_df.rename(join_column_renames)
+        join_columns = [join_column_renames[col] for col in join_columns]
+
+        all_user_columns = list(
+            set(base_lazy_df.collect().columns) | set(compare_lazy_df.collect().columns)
+        )
+
+        # Check for reserved internal column names in user data
+
+        column_mapping = _generate_column_mapping(
+            all_user_columns,
+            value_alias=value_alias,
+            variable_alias=variable_alias,
+            base_alias=base_alias,
+            compare_alias=compare_alias,
+        )
+
+        reserved_columns = set(column_mapping.mapping.keys())        
+        conflicting_columns = reserved_columns.intersection(set(all_user_columns))
+        if conflicting_columns:
+            raise ValueError(
+                f"Column name(s) {conflicting_columns} are reserved for internal use. "
+                f"Please rename these columns in your dataframes. "
+                f"All columns starting with '__pl_compare_' are reserved."
+            )
+
         self._comparison_metadata = ComparisonMetadata(
             join_columns,
             base_lazy_df,
@@ -531,6 +699,7 @@ class compare:
             False,
             hide_empty_stats,
             validate,
+            column_mapping,
         )
         self._created_frames: Dict[str, Union[pl.DataFrame, pl.LazyFrame]] = {}
 

--- a/pl_compare/tests/test_compare.py
+++ b/pl_compare/tests/test_compare.py
@@ -73,14 +73,14 @@ shape: (5, 2)
 │ Rows in test and other ┆ 2     │
 └────────────────────────┴───────┘
 shape: (2, 3)
-┌────────────┬──────────┬───────────────┐
-│ ID         ┆ variable ┆ value         │
-│ ---        ┆ ---      ┆ ---           │
-│ str        ┆ str      ┆ str           │
-╞════════════╪══════════╪═══════════════╡
-│ 12345678   ┆ status   ┆ in test only  │
-│ 1234567810 ┆ status   ┆ in other only │
-└────────────┴──────────┴───────────────┘""" in str(
+┌─────────────────┬──────────┬───────────────┐
+│ join_columns.ID ┆ variable ┆ value         │
+│ ---             ┆ ---      ┆ ---           │
+│ str             ┆ str      ┆ str           │
+╞═════════════════╪══════════╪═══════════════╡
+│ 12345678        ┆ status   ┆ in test only  │
+│ 1234567810      ┆ status   ┆ in other only │
+└─────────────────┴──────────┴───────────────┘""" in str(
         compare_result.report()
     )
     assert """VALUE DIFFERENCES:
@@ -94,32 +94,56 @@ shape: (2, 3)
 │ Example1                ┆ 1     ┆ 50.0       │
 └─────────────────────────┴───────┴────────────┘
 shape: (1, 4)
-┌─────────┬──────────┬──────┬───────┐
-│ ID      ┆ variable ┆ test ┆ other │
-│ ---     ┆ ---      ┆ ---  ┆ ---   │
-│ str     ┆ str      ┆ str  ┆ str   │
-╞═════════╪══════════╪══════╪═══════╡
-│ 1234567 ┆ Example1 ┆ 6    ┆ 2     │
-└─────────┴──────────┴──────┴───────┘""" in str(
+┌─────────────────┬──────────┬──────┬───────┐
+│ join_columns.ID ┆ variable ┆ test ┆ other │
+│ ---             ┆ ---      ┆ ---  ┆ ---   │
+│ str             ┆ str      ┆ str  ┆ str   │
+╞═════════════════╪══════════╪══════╪═══════╡
+│ 1234567         ┆ Example1 ┆ 6    ┆ 2     │
+└─────────────────┴──────────┴──────┴───────┘""" in str(
         compare_result.report()
     )
 
 
-@pytest.mark.parametrize("column_name", ["value", "variable"])
+@pytest.mark.parametrize(
+    "column_name",
+    [
+        "value",
+        "variable",
+        "in_base",
+        "in_compare",
+        "status",
+        "join_columns",
+        "base",
+        "compare",
+        "Count",
+        "column",
+        "Statistic",
+        "ID",
+        "Percentage",
+        "format",
+        "base_format",
+        "compare_format",
+        "Value Differences",
+    ],
+)
 def test_special_column_names(column_name):
     base_df = pl.DataFrame({column_name: ["123", "456", "888"], "x": [1, 2, 3]})
     compare_df = pl.DataFrame({column_name: ["123", "456", "789"], "x": [1, 22, 3]})
+    # With consistent join column prefixing, ALL join columns are always prefixed
+    join_col = f"join_columns.{column_name}"
+
     expected_rows = pl.DataFrame(
         {
-            column_name: ["888", "789"],
-            "-variable": ["status", "status"],
-            "-value": ["in base only", "in compare only"],
+            join_col: ["888", "789"],
+            "variable": ["status", "status"],
+            "value": ["in base only", "in compare only"],
         }
     )
     expected_values = pl.DataFrame(
         {
-            column_name: ["456"],
-            "-variable": ["x"],
+            join_col: ["456"],
+            "variable": ["x"],
             "base": ["2"],
             "compare": ["22"],
         }
@@ -128,12 +152,34 @@ def test_special_column_names(column_name):
     # Without value_alias and variable_alias, the special column names would produce
     #    polars.exceptions.DuplicateError: projections contained duplicate output name 'variable'
     # because the same column names are used internally.
-    compare_result = compare(
-        [column_name], base_df, compare_df, value_alias="-value", variable_alias="-variable"
-    )
+    compare_result = compare([column_name], base_df, compare_df)
 
+    # Test multiple methods that use column aliases
     pl.testing.assert_frame_equal(compare_result.rows_sample(), expected_rows)
     pl.testing.assert_frame_equal(compare_result.values_sample(), expected_values)
+
+    schemas_sample = compare_result.schemas_sample()
+    assert "column" in schemas_sample.columns
+
+    rows_summary = compare_result.rows_summary()
+    assert rows_summary.height > 0
+    assert "Statistic" in rows_summary.columns
+    assert "Count" in rows_summary.columns
+
+    values_summary = compare_result.values_summary()
+    assert values_summary.height > 0
+    assert "Value Differences" in values_summary.columns
+    assert "Count" in values_summary.columns
+    assert "Percentage" in values_summary.columns
+
+    summary = compare_result.summary()
+    assert summary.height > 0
+    assert "Statistic" in summary.columns
+    assert "Count" in summary.columns
+
+    assert compare_result.is_rows_equal() is False  # Rows differ
+    assert compare_result.is_values_equal() is False  # Values differ
+    assert compare_result.is_equal() is False  # Overall not equal
 
 
 def test_expected_values_returned_for_bools_for_equal_dfs_none_id_columns(base_df):
@@ -232,7 +278,7 @@ def test_expected_values_returned_row_differences(base_df, compare_df):
     compare_result = compare(["ID"], base_df, compare_df)
     expected_row_differences = pl.DataFrame(
         {
-            "ID": ["12345678", "1234567810"],
+            "join_columns.ID": ["12345678", "1234567810"],
             "variable": ["status", "status"],
             "value": ["in base only", "in compare only"],
         }
@@ -258,7 +304,7 @@ def test_expected_values_returned_values_summary(base_df, compare_df):
 def test_expected_values_returned_value_differences(base_df, compare_df):
     compare_result = compare(["ID"], base_df, compare_df)
     expected_value_differences = pl.DataFrame(
-        {"ID": ["1234567"], "variable": ["Example1"], "base": ["6"], "compare": ["2"]}
+        {"join_columns.ID": ["1234567"], "variable": ["Example1"], "base": ["6"], "compare": ["2"]}
     )
     assert_frame_equal(compare_result.values_sample(), expected_value_differences)
 
@@ -465,10 +511,10 @@ def test_error_raised_when_dupes_supplied_for_1_1_validation():
     with pytest.raises(pl.exceptions.ComputeError):
         compare(["ID"], compare_df, base_df, validate="m:1").rows_summary()
 
-    compare(["ID", "ID2"], base_df, compare_df, "m:1").values_summary()
-    compare(["ID", "ID2"], base_df, compare_df, "m:1").rows_summary()
-    compare(["ID", "ID2"], compare_df, base_df, "1:m").values_summary()
-    compare(["ID", "ID2"], compare_df, base_df, "1:m").rows_summary()
+    compare(["ID", "ID2"], base_df, compare_df, validate="m:1").values_summary()
+    compare(["ID", "ID2"], base_df, compare_df, validate="m:1").rows_summary()
+    compare(["ID", "ID2"], compare_df, base_df, validate="1:m").values_summary()
+    compare(["ID", "ID2"], compare_df, base_df, validate="1:m").rows_summary()
 
 
 def test_for_single_column_table_columns():
@@ -529,15 +575,17 @@ shape: (5, 2)
 │ Rows in base and compare ┆ 2     │
 └──────────────────────────┴───────┘
 shape: (3, 6)
-┌────────────┬────────────┬────────────┬────────────┬──────────┬─────────────────┐
-│ ID         ┆ ID2        ┆ ID3        ┆ ID4        ┆ variable ┆ value           │
-│ ---        ┆ ---        ┆ ---        ┆ ---        ┆ ---      ┆ ---             │
-│ str        ┆ str        ┆ str        ┆ str        ┆ str      ┆ str             │
-╞════════════╪════════════╪════════════╪════════════╪══════════╪═════════════════╡
-│ 123456     ┆ 123457     ┆ 123457     ┆ 123457     ┆ status   ┆ in base only    │
-│ 1234567810 ┆ 1234567810 ┆ 1234567810 ┆ 1234567810 ┆ status   ┆ in compare only │
-│ 12345678   ┆ 12345678   ┆ 12345678   ┆ 12345678   ┆ status   ┆ in base only    │
-└────────────┴────────────┴────────────┴────────────┴──────────┴─────────────────┘
+┌─────────────────┬─────────────────┬─────────────────┬────────────────┬──────────┬────────────────┐
+│ join_columns.ID ┆ join_columns.ID ┆ join_columns.ID ┆ join_columns.I ┆ variable ┆ value          │
+│ ---             ┆ 2               ┆ 3               ┆ D4             ┆ ---      ┆ ---            │
+│ str             ┆ ---             ┆ ---             ┆ ---            ┆ str      ┆ str            │
+│                 ┆ str             ┆ str             ┆ str            ┆          ┆                │
+╞═════════════════╪═════════════════╪═════════════════╪════════════════╪══════════╪════════════════╡
+│ 123456          ┆ 123457          ┆ 123457          ┆ 123457         ┆ status   ┆ in base only   │
+│ 1234567810      ┆ 1234567810      ┆ 1234567810      ┆ 1234567810     ┆ status   ┆ in compare     │
+│                 ┆                 ┆                 ┆                ┆          ┆ only           │
+│ 12345678        ┆ 12345678        ┆ 12345678        ┆ 12345678       ┆ status   ┆ in base only   │
+└─────────────────┴─────────────────┴─────────────────┴────────────────┴──────────┴────────────────┘
 """ in str(
         comp.report()
     )
@@ -625,4 +673,202 @@ def test_usage_of_status_column():
     )
 
     # This should not cause an error
-    compare(["status"], base_df, compare_df)
+    compare_result = compare(["status"], base_df, compare_df)
+
+
+def test_column_aliases_in_metadata():
+    """Test that value_alias and variable_alias are properly stored in column mapping."""
+    base_df = pl.DataFrame(
+        {
+            "ID": [1, 2, 3],
+            "value": [10, 20, 30],
+            "variable": ["a", "b", "c"],
+        }
+    )
+    compare_df = pl.DataFrame(
+        {
+            "ID": [1, 2, 4],
+            "value": [10, 25, 40],
+            "variable": ["a", "x", "y"],
+        }
+    )
+
+    # Test with default aliases
+    result_default = compare(["ID"], base_df, compare_df)
+    meta_default = result_default._comparison_metadata
+
+    # Verify default aliases are in column mapping
+    assert meta_default.column_mapping.mapping["__pl_compare_value"] == "value"
+    assert meta_default.column_mapping.mapping["__pl_compare_variable"] == "variable"
+
+    # Test with custom aliases
+    result_custom = compare(
+        ["ID"], base_df, compare_df, value_alias="custom_value", variable_alias="custom_var"
+    )
+    meta_custom = result_custom._comparison_metadata
+
+    # Verify custom aliases are in column mapping
+    assert meta_custom.column_mapping.mapping["__pl_compare_value"] == "custom_value"
+    assert meta_custom.column_mapping.mapping["__pl_compare_variable"] == "custom_var"
+
+    # Verify that ComparisonMetadata no longer has value_alias and variable_alias attributes
+    assert not hasattr(meta_default, "value_alias")
+    assert not hasattr(meta_default, "variable_alias")
+    assert not hasattr(meta_custom, "value_alias")
+    assert not hasattr(meta_custom, "variable_alias")
+
+    # Test that the custom aliases appear in the output
+    row_diff = result_custom.rows_sample()
+    assert "custom_var" in row_diff.columns
+    assert "custom_value" in row_diff.columns
+
+    value_diff = result_custom.values_sample()
+    assert "custom_var" in value_diff.columns
+    assert "custom_value" not in value_diff.columns  # value is base/compare columns
+    assert "base" in value_diff.columns
+    assert "compare" in value_diff.columns
+
+
+def test_column_aliases_with_special_names():
+    """Test that column aliases work correctly with special column names."""
+    # Test with 'value' as a user column name
+    base_df = pl.DataFrame(
+        {
+            "ID": [1, 2, 3],
+            "value": [10, 20, 30],  # User column named 'value'
+            "data": ["a", "b", "c"],
+        }
+    )
+    compare_df = pl.DataFrame(
+        {
+            "ID": [1, 2, 4],
+            "value": [10, 25, 40],  # User column named 'value'
+            "data": ["a", "x", "y"],
+        }
+    )
+
+    # Use custom aliases to avoid conflict
+    result = compare(
+        ["ID"], base_df, compare_df, value_alias="result_value", variable_alias="result_var"
+    )
+
+    # Verify the output uses custom aliases
+    row_diff = result.rows_sample()
+    assert "result_var" in row_diff.columns
+    assert "result_value" in row_diff.columns
+    assert "join_columns.ID" in row_diff.columns
+
+    # Verify user's 'value' column is preserved with join_columns prefix
+    assert "value" not in row_diff.columns  # Should be prefixed
+
+    value_diff = result.values_sample()
+    assert "result_var" in value_diff.columns
+    assert "base" in value_diff.columns
+    assert "compare" in value_diff.columns
+
+
+def test_reserved_column_names_error():
+    """Test that using reserved internal column names raises an appropriate error."""
+    base_df = pl.DataFrame({
+        "__pl_compare_value": [1, 2, 3],
+        "ID": [1, 2, 3],
+        "data": ["a", "b", "c"]
+    })
+    compare_df = pl.DataFrame({
+        "__pl_compare_status": ["x", "y", "z"],
+        "ID": [1, 2, 3],
+        "data": ["a", "b", "c"]
+    })
+    
+    # Test single reserved column
+    with pytest.raises(ValueError, match="Column name.*are reserved for internal use"):
+        compare(["ID"], base_df, compare_df)
+    
+    # Test multiple reserved columns
+    base_df_multi = pl.DataFrame({
+        "__pl_compare_value": [1, 2, 3],
+        "__pl_compare_base": [10, 20, 30],
+        "ID": [1, 2, 3]
+    })
+    
+    with pytest.raises(ValueError, match="Column name.*are reserved for internal use"):
+        compare(["ID"], base_df_multi, base_df_multi)
+    
+    # Test that the error message mentions the pattern
+    with pytest.raises(ValueError, match="All columns starting with '__pl_compare_' are reserved"):
+        compare(["ID"], base_df, compare_df)
+
+
+def test_reserved_column_names_error_specific_columns():
+    """Test error for each specific reserved column name."""
+    reserved_columns = [
+        "__pl_compare_in_base",
+        "__pl_compare_in_compare",
+        "__pl_compare_value",
+        "__pl_compare_variable",
+        "__pl_compare_base",
+        "__pl_compare_compare",
+        "__pl_compare_status"
+    ]
+    
+    for reserved_col in reserved_columns:
+        base_df = pl.DataFrame({
+            reserved_col: [1, 2, 3],
+            "ID": [1, 2, 3],
+            "data": ["a", "b", "c"]
+        })
+        compare_df = pl.DataFrame({
+            "ID": [1, 2, 3],
+            "data": ["a", "b", "c"]
+        })
+        
+        with pytest.raises(ValueError, match=f"Column name.*{reserved_col}.*are reserved"):
+            compare(["ID"], base_df, compare_df)
+
+
+def test_apply_column_renames_type_error():
+    """Test that @apply_column_renames raises TypeError for non-DataFrame/LazyFrame results."""
+    from pl_compare.compare import apply_column_renames, ComparisonMetadata, ColumnMapping
+    
+    # Create a mock function that returns an invalid type
+    @apply_column_renames
+    def mock_function_returns_string(meta: ComparisonMetadata):
+        return "invalid_result"
+    
+    @apply_column_renames  
+    def mock_function_returns_int(meta: ComparisonMetadata):
+        return 42
+    
+    @apply_column_renames
+    def mock_function_returns_list(meta: ComparisonMetadata):
+        return [1, 2, 3]
+    
+    # Create a mock metadata object
+    mock_meta = ComparisonMetadata(
+        join_columns=["ID"],
+        base_df=pl.LazyFrame({"ID": [1, 2, 3]}),
+        compare_df=pl.LazyFrame({"ID": [1, 2, 3]}),
+        streaming=False,
+        resolution=None,
+        equality_check=None,
+        sample_limit=None,
+        base_alias="base",
+        compare_alias="compare",
+        schema_comparison=False,
+        hide_empty_stats=False,
+        validate="m:m",
+        column_mapping=ColumnMapping(mapping={"__pl_compare_value": "value"})
+    )
+    
+    # Test string result
+    with pytest.raises(TypeError, match="Expected result to be a polars DataFrame or LazyFrame"):
+        mock_function_returns_string(mock_meta)
+    
+    # Test int result
+    with pytest.raises(TypeError, match="Expected result to be a polars DataFrame or LazyFrame"):
+        mock_function_returns_int(mock_meta)
+    
+    # Test list result
+    with pytest.raises(TypeError, match="Expected result to be a polars DataFrame or LazyFrame"):
+        mock_function_returns_list(mock_meta)
+    


### PR DESCRIPTION
This PR fixes potential conflicts between user supplied column names, columns used internally and columns used in the output dataframes;
- Prefixed join columns in the output with `join_columns`
- Separated internal column names from output column names and added metadata class and decorator to handle renaming.
- Added an error message for the unlikely event that a user supplies the new internal column names.
- Added more tests to check for internal/output column conflicts.